### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module matryoshka
+module github.com/smokezl/matryoshka
 
 go 1.13
 

--- a/qps.go
+++ b/qps.go
@@ -57,11 +57,11 @@ func (q *qps) statisticsTotal() {
 	}()
 	ticker := time.NewTicker(time.Second)
 	for range ticker.C {
-		q.all.viewTotal = atomic.SwapInt64(&q.all.total, 0)
-		q.memoryTotal.viewTotal = atomic.SwapInt64(&q.memoryTotal.total, 0)
-		q.memoryHit.viewTotal = atomic.SwapInt64(&q.memoryHit.total, 0)
-		q.redisTotal.viewTotal = atomic.SwapInt64(&q.redisTotal.total, 0)
-		q.redisHit.viewTotal = atomic.SwapInt64(&q.redisHit.total, 0)
-		q.sourceTotal.viewTotal = atomic.SwapInt64(&q.sourceTotal.total, 0)
+		q.all.viewTotal += atomic.SwapInt64(&q.all.total, 0)
+		q.memoryTotal.viewTotal += atomic.SwapInt64(&q.memoryTotal.total, 0)
+		q.memoryHit.viewTotal += atomic.SwapInt64(&q.memoryHit.total, 0)
+		q.redisTotal.viewTotal += atomic.SwapInt64(&q.redisTotal.total, 0)
+		q.redisHit.viewTotal += atomic.SwapInt64(&q.redisHit.total, 0)
+		q.sourceTotal.viewTotal += atomic.SwapInt64(&q.sourceTotal.total, 0)
 	}
 }


### PR DESCRIPTION
修复 引用mod的如下报错
go: github.com/smokezl/matryoshka@v1.0.1: parsing go.mod:
        module declares its path as: matryoshka
                but was required as: github.com/smokezl/matryoshka